### PR TITLE
Configure Lint workflow

### DIFF
--- a/.github/lint.yml
+++ b/.github/lint.yml
@@ -1,0 +1,17 @@
+name: flake8 Lint
+
+on: [push, pull_request]
+
+jobs:
+  flake8-lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: Set up Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2


### PR DESCRIPTION
This PR adds configuration for the Lint workflow on GitHub, so linting errors are properly checked and reported on `push` or `pull_request`.